### PR TITLE
Fix type name and a few small fixes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
 const fetch = require('node-fetch');
 const URL = require('url').URL;
 
-interface DataObj {
+type WPCountData = {
   title: string;
   url: string;
   content: string;
   wordcount: number;
-}
+};
 
 const fetchData = async (
   url: string,
   page: number
-): Promise<Array<DataObj>> => {
+): Promise<Array<WPCountData>> => {
   const perPage = 100;
 
   const targetUrl = `${url}?per_page=${perPage}&page=${page}`;
@@ -33,7 +33,7 @@ const removeHtmlTag = (text: string): string => {
   return text.replace(/(<([^>]+)>)/gi, '').replace(/\n/gi, '');
 };
 
-module.exports = async (url: string): Promise<Array<DataObj>> => {
+module.exports = async (url: string): Promise<Array<WPCountData>> => {
   try {
     new URL(url);
   } catch (e) {
@@ -41,7 +41,7 @@ module.exports = async (url: string): Promise<Array<DataObj>> => {
     throw e;
   }
 
-  let postList: Array<DataObj> = [];
+  let postList: Array<WPCountData> = [];
 
   const targetUrl = `${url}/wp-json/wp/v2/posts`;
   const response = await fetch(targetUrl);

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,8 +41,6 @@ module.exports = async (url: string): Promise<Array<WPCountData>> => {
     throw e;
   }
 
-  let postList: Array<WPCountData> = [];
-
   const targetUrl = `${url}/wp-json/wp/v2/posts`;
   const response = await fetch(targetUrl);
   const wpTotalPageCount: string | null = response.headers.get('X-WP-Total');
@@ -51,6 +49,7 @@ module.exports = async (url: string): Promise<Array<WPCountData>> => {
     return [];
   }
 
+  let postList: Array<WPCountData> = [];
   const paginationCount = Math.ceil(Number(wpTotalPageCount) / 100);
 
   for (let i = 1; i <= paginationCount; i++) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,8 +45,13 @@ module.exports = async (url: string): Promise<Array<WPCountData>> => {
 
   const targetUrl = `${url}/wp-json/wp/v2/posts`;
   const response = await fetch(targetUrl);
-  const wpTotalPageCount = response.headers.get('X-WP-Total');
-  const paginationCount = Math.ceil(wpTotalPageCount / 100);
+  const wpTotalPageCount: string | null = response.headers.get('X-WP-Total');
+
+  if (wpTotalPageCount) {
+    return [];
+  }
+
+  const paginationCount = Math.ceil(Number(wpTotalPageCount) / 100);
 
   for (let i = 1; i <= paginationCount; i++) {
     const contentData = await fetchData(targetUrl, i);


### PR DESCRIPTION
Fix type name and a few small fixes.
* interface -> type alias and rename (https://github.com/shinshin86/wp-rest-api-posts-wordcount/commit/67d37e98ee6afe887e46bd016a2c248071b48920)
* Add null pattern (https://github.com/shinshin86/wp-rest-api-posts-wordcount/commit/66ecb12da5f70929f348e53d1927ce83ac84e43d)
* Move variable definitions (https://github.com/shinshin86/wp-rest-api-posts-wordcount/pull/1/commits/1e48857290a54ae5ad1f1f939defb603e24c5eed)